### PR TITLE
Use a seperate "smaller" struct to pass the bot to handlers

### DIFF
--- a/examples/multiple_handlers.rs
+++ b/examples/multiple_handlers.rs
@@ -5,9 +5,10 @@ extern crate config;
 extern crate rand;
 
 extern crate matrix_bot_api;
-use matrix_bot_api::{MatrixBot, MessageType};
-use matrix_bot_api::handlers::{Message, MessageHandler, StatelessHandler, extract_command, HandleResult};
-
+use matrix_bot_api::handlers::{
+    extract_command, HandleResult, Message, MessageHandler, StatelessHandler,
+};
+use matrix_bot_api::{ActiveBot, MatrixBot, MessageType};
 
 fn main() {
     // ------- Getting the login-credentials from file -------
@@ -16,10 +17,12 @@ fn main() {
     // load from botconfig.toml.
     // Change this file to your needs, if you want to use this example binary.
     let mut settings = config::Config::default();
-    settings.merge(config::File::with_name("examples/botconfig")).unwrap();
+    settings
+        .merge(config::File::with_name("examples/botconfig"))
+        .unwrap();
 
     let user = settings.get_str("user").unwrap();
-    let password  = settings.get_str("password").unwrap();
+    let password = settings.get_str("password").unwrap();
     let homeserver_url = settings.get_str("homeserver_url").unwrap();
     // -------------------------------------------------------
 
@@ -64,7 +67,6 @@ fn main() {
     bot.run(&user, &password, &homeserver_url);
 }
 
-
 // We can register multiple handlers. Thus, we create some here.
 
 // --------- Definition of 1. handler -----------
@@ -75,10 +77,10 @@ pub struct CounterHandler {
 
 impl CounterHandler {
     fn new() -> CounterHandler {
-        CounterHandler{counter: 0}
+        CounterHandler { counter: 0 }
     }
 
-    fn show_help(&mut self, bot: &MatrixBot, message: &Message) -> HandleResult {
+    fn show_help(&mut self, bot: &ActiveBot, message: &Message) -> HandleResult {
         let mut help = "Counter:\n".to_string();
         help += "!incr = Increases counter by one\n";
         help += "!decr = Decreases counter by one\n";
@@ -89,18 +91,22 @@ impl CounterHandler {
 }
 
 impl MessageHandler for CounterHandler {
-    fn handle_message(&mut self, bot: &MatrixBot, message: &Message) -> HandleResult {
+    fn handle_message(&mut self, bot: &ActiveBot, message: &Message) -> HandleResult {
         let command = match extract_command(&message.body, "!") {
             Some(x) => x,
             None => return HandleResult::ContinueHandling,
         };
 
         match command {
-          "incr" => self.counter += 1,
-          "decr" => self.counter -= 1,
-          "show" => bot.send_message(&format!("Counter = {}", self.counter), &message.room, MessageType::RoomNotice),
-          "help" => return self.show_help(bot, message),
-          _ => return HandleResult::ContinueHandling /* Not a known command */
+            "incr" => self.counter += 1,
+            "decr" => self.counter -= 1,
+            "show" => bot.send_message(
+                &format!("Counter = {}", self.counter),
+                &message.room,
+                MessageType::RoomNotice,
+            ),
+            "help" => return self.show_help(bot, message),
+            _ => return HandleResult::ContinueHandling, /* Not a known command */
         }
         HandleResult::StopHandling
     }
@@ -108,13 +114,13 @@ impl MessageHandler for CounterHandler {
 
 // --------- Definition for 2. handler -----------
 // Copied from stateless.rs
-fn whoareyou(bot: &MatrixBot, message: &Message, _cmd: &str) -> HandleResult {
+fn whoareyou(bot: &ActiveBot, message: &Message, _cmd: &str) -> HandleResult {
     bot.send_message("I'm a bot.", &message.room, MessageType::RoomNotice);
     HandleResult::StopHandling
 }
 
 // --------- Definition for 3. handler -----------
-fn roll_help(bot: &MatrixBot, message: &Message, _cmd: &str) -> HandleResult {
+fn roll_help(bot: &ActiveBot, message: &Message, _cmd: &str) -> HandleResult {
     let mut help = "Roll dice:\n".to_string();
     help += "!roll X [X ..]\n";
     help += "with\n";
@@ -125,7 +131,7 @@ fn roll_help(bot: &MatrixBot, message: &Message, _cmd: &str) -> HandleResult {
     HandleResult::ContinueHandling /* There might be more handlers that implement "help" */
 }
 
-fn roll_dice(bot: &MatrixBot, message: &Message, cmd: &str) -> HandleResult {
+fn roll_dice(bot: &ActiveBot, message: &Message, cmd: &str) -> HandleResult {
     let room = &message.room;
     let cmd_split = cmd.split_whitespace();
 
@@ -133,8 +139,14 @@ fn roll_dice(bot: &MatrixBot, message: &Message, cmd: &str) -> HandleResult {
     for dice in cmd_split {
         let sides = match dice.parse::<u32>() {
             Ok(x) => x,
-            Err(_) => { bot.send_message(&format!("{} is not a number.", dice), room, MessageType::RoomNotice);
-                        return HandleResult::StopHandling; }
+            Err(_) => {
+                bot.send_message(
+                    &format!("{} is not a number.", dice),
+                    room,
+                    MessageType::RoomNotice,
+                );
+                return HandleResult::StopHandling;
+            }
         };
         results.push((rand::random::<u32>() % sides) + 1);
     }
@@ -146,11 +158,14 @@ fn roll_dice(bot: &MatrixBot, message: &Message, cmd: &str) -> HandleResult {
     if results.len() == 1 {
         bot.send_message(&format!("{}", results[0]), room, MessageType::RoomNotice);
     } else {
-       // make string from results:
-       let str_res : Vec<String> = results.iter().map(|x| x.to_string()).collect();
-       bot.send_message(&format!("{} = {}", str_res.join(" + "), results.iter().sum::<u32>()), room, MessageType::RoomNotice);
+        // make string from results:
+        let str_res: Vec<String> = results.iter().map(|x| x.to_string()).collect();
+        bot.send_message(
+            &format!("{} = {}", str_res.join(" + "), results.iter().sum::<u32>()),
+            room,
+            MessageType::RoomNotice,
+        );
     }
 
     HandleResult::StopHandling
 }
-

--- a/examples/stateless.rs
+++ b/examples/stateless.rs
@@ -3,11 +3,11 @@
 extern crate config;
 
 extern crate matrix_bot_api;
-use matrix_bot_api::{MatrixBot, MessageType};
-use matrix_bot_api::handlers::{Message, StatelessHandler, HandleResult};
+use matrix_bot_api::handlers::{HandleResult, Message, StatelessHandler};
+use matrix_bot_api::{ActiveBot, MatrixBot, MessageType};
 
 // Handle that prints "I'm a bot." as a room-notice on command !whoareyou
-fn whoareyou(bot: &MatrixBot, message: &Message, _tail: &str) -> HandleResult {
+fn whoareyou(bot: &ActiveBot, message: &Message, _tail: &str) -> HandleResult {
     bot.send_message("I'm a bot.", &message.room, MessageType::RoomNotice);
     HandleResult::StopHandling
 }
@@ -19,10 +19,12 @@ fn main() {
     // load from botconfig.toml.
     // Change this file to your needs, if you want to use this example binary.
     let mut settings = config::Config::default();
-    settings.merge(config::File::with_name("examples/botconfig")).unwrap();
+    settings
+        .merge(config::File::with_name("examples/botconfig"))
+        .unwrap();
 
     let user = settings.get_str("user").unwrap();
-    let password  = settings.get_str("password").unwrap();
+    let password = settings.get_str("password").unwrap();
     let homeserver_url = settings.get_str("homeserver_url").unwrap();
     // -------------------------------------------------------
 
@@ -44,7 +46,11 @@ fn main() {
 
     // Simply echo what was given to you by !echo XY (will print only "Echo: XY", !echo is stripped)
     handler.register_handle("echo", |bot, message, tail| {
-        bot.send_message(&format!("Echo: {}", tail), &message.room, MessageType::TextMessage);
+        bot.send_message(
+            &format!("Echo: {}", tail),
+            &message.room,
+            MessageType::TextMessage,
+        );
         HandleResult::StopHandling
     });
 

--- a/examples/with_state.rs
+++ b/examples/with_state.rs
@@ -3,8 +3,8 @@
 extern crate config;
 
 extern crate matrix_bot_api;
-use matrix_bot_api::{MatrixBot, MessageType};
-use matrix_bot_api::handlers::{Message, MessageHandler, extract_command, HandleResult};
+use matrix_bot_api::handlers::{extract_command, HandleResult, Message, MessageHandler};
+use matrix_bot_api::{ActiveBot, MatrixBot, MessageType};
 
 // Our handler wants a mutable state (here represented by a little counter-variable)
 // This counter can be increased or decreased by users giving the bot a command.
@@ -14,7 +14,7 @@ pub struct CounterHandler {
 
 impl CounterHandler {
     fn new() -> CounterHandler {
-        CounterHandler{counter: 0}
+        CounterHandler { counter: 0 }
     }
 }
 
@@ -22,7 +22,7 @@ impl CounterHandler {
 // This trait only has one function: handle_message() and will be called on each
 // new (text-)message in the room the bot is in.
 impl MessageHandler for CounterHandler {
-    fn handle_message(&mut self, bot: &MatrixBot, message: &Message) -> HandleResult {
+    fn handle_message(&mut self, bot: &ActiveBot, message: &Message) -> HandleResult {
         // extract_command() will split the message by whitespace and remove the prefix (here "!")
         // from the first entry. If the message does not start with the given prefix, None is returned.
         let command = match extract_command(&message.body, "!") {
@@ -35,11 +35,15 @@ impl MessageHandler for CounterHandler {
         // and a specific function for it (like StatelessHandler does it),
         // or you can use a simple match-statement, to act on the given command:
         match command {
-          "incr" => self.counter += 1,
-          "decr" => self.counter -= 1,
-          "show" => bot.send_message(&format!("Counter = {}", self.counter), &message.room, MessageType::RoomNotice),
-          "shutdown" => bot.shutdown(),
-          _ => return HandleResult::ContinueHandling /* Not a known command */
+            "incr" => self.counter += 1,
+            "decr" => self.counter -= 1,
+            "show" => bot.send_message(
+                &format!("Counter = {}", self.counter),
+                &message.room,
+                MessageType::RoomNotice,
+            ),
+            "shutdown" => bot.shutdown(),
+            _ => return HandleResult::ContinueHandling, /* Not a known command */
         }
         HandleResult::StopHandling
     }
@@ -52,10 +56,12 @@ fn main() {
     // load from botconfig.toml.
     // Change this file to your needs, if you want to use this example binary.
     let mut settings = config::Config::default();
-    settings.merge(config::File::with_name("examples/botconfig")).unwrap();
+    settings
+        .merge(config::File::with_name("examples/botconfig"))
+        .unwrap();
 
     let user = settings.get_str("user").unwrap();
-    let password  = settings.get_str("password").unwrap();
+    let password = settings.get_str("password").unwrap();
     let homeserver_url = settings.get_str("homeserver_url").unwrap();
     // -------------------------------------------------------
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,13 +1,13 @@
-use super::MatrixBot;
+
 
 pub use fractal_matrix_api::types::Message;
 
 /// What to do after finished handling a message
 pub enum HandleResult {
-	/// Give this message to the next MessageHandler as well
-	ContinueHandling,
-	/// Stop handling this message
-	StopHandling
+    /// Give this message to the next MessageHandler as well
+    ContinueHandling,
+    /// Stop handling this message
+    StopHandling,
 }
 
 /// Any struct that implements this trait can be passed to a MatrixBot.
@@ -15,7 +15,7 @@ pub enum HandleResult {
 /// The result HandleResult defines if `handle_message()` of other handlers will
 /// be called with this message or not.
 pub trait MessageHandler {
-    fn handle_message(&mut self, bot: &MatrixBot, message: &Message) -> HandleResult;
+    fn handle_message(&mut self, bot: &ActiveBot, message: &Message) -> HandleResult;
 }
 
 /// Convenience-function to split the incoming message by whitespace and
@@ -25,7 +25,7 @@ pub trait MessageHandler {
 /// extract_command("!roll 6", "!") will return Some("roll")
 /// extract_command("Hi all!", "!") will return None
 pub fn extract_command<'a>(message: &'a str, prefix: &str) -> Option<&'a str> {
-	if message.starts_with(prefix) {
+    if message.starts_with(prefix) {
         let new_start = prefix.len();
         let key = message[new_start..].split_whitespace().next().unwrap();
         return Some(&key);
@@ -35,3 +35,6 @@ pub fn extract_command<'a>(message: &'a str, prefix: &str) -> Option<&'a str> {
 
 pub mod stateless_handler;
 pub use self::stateless_handler::StatelessHandler;
+
+
+use crate::ActiveBot;

--- a/src/handlers/stateless_handler.rs
+++ b/src/handlers/stateless_handler.rs
@@ -1,18 +1,20 @@
+use crate::handlers::{extract_command, HandleResult, Message, MessageHandler};
 use std::collections::HashMap;
-use crate::handlers::{Message, MessageHandler, extract_command, HandleResult};
-use super::MatrixBot;
+use crate::ActiveBot;
 
 /// Convenience-handler that can quickly register and call functions
 /// without any state (each function-call will result in the same output)
 pub struct StatelessHandler {
     cmd_prefix: String,
-    cmd_handles: HashMap<String, fn(&MatrixBot, &Message, &str) -> HandleResult>,
+    cmd_handles: HashMap<String, fn(&ActiveBot, &Message, &str) -> HandleResult>,
 }
 
 impl StatelessHandler {
     pub fn new() -> StatelessHandler {
-        StatelessHandler{cmd_prefix: "!".to_string(),
-                      cmd_handles: HashMap::new()}
+        StatelessHandler {
+            cmd_prefix: "!".to_string(),
+            cmd_handles: HashMap::new(),
+        }
     }
 
     /// With what prefix commands to the bot will start
@@ -34,36 +36,39 @@ impl StatelessHandler {
     /// handler.set_cmd_prefix("BOT:")
     /// handler.register_handle("sayhi", foo);
     /// foo() will be called, when BOT:sayhi is received by the bot
-    pub fn register_handle(&mut self,
-                           command: &str,
-                           handler: fn(bot: &MatrixBot, message: &Message, tail: &str) -> HandleResult)
-    {
+    pub fn register_handle(
+        &mut self,
+        command: &str,
+        handler: fn(bot: &ActiveBot, message: &Message, tail: &str) -> HandleResult,
+    ) {
         self.cmd_handles.insert(command.to_string(), handler);
     }
 }
 
 impl MessageHandler for StatelessHandler {
-    fn handle_message(&mut self, bot: &MatrixBot, message: &Message) -> HandleResult {
+    fn handle_message(&mut self, bot: &ActiveBot, message: &Message) -> HandleResult {
         match extract_command(&message.body, &self.cmd_prefix) {
             Some(command) => {
-                                let func = self.cmd_handles.get(command).map(|x| *x);
-                                match func {
-                                    Some(func) => {
-                                        if bot.verbose {
-                                            println!("Found handle for command \"{}\". Calling it.", &command);
-                                        }
-                                        let end_of_prefix = self.cmd_prefix.len() + command.len();
-                                        func(bot, message, &message.body[end_of_prefix..])
-                                    }
-                                    None => {
-                                        if bot.verbose {
-                                            println!("Command \"{}\" not found in registered handles", &command);
-                                        }
-                                        HandleResult::ContinueHandling
-                                    }
-                                }
-                            }
-            None => { HandleResult::ContinueHandling /* Doing nothing. Not for us */}
+                let func = self.cmd_handles.get(command).map(|x| *x);
+                match func {
+                    Some(func) => {
+                        if bot.verbose {
+                            println!("Found handle for command \"{}\". Calling it.", &command);
+                        }
+                        let end_of_prefix = self.cmd_prefix.len() + command.len();
+                        func(bot, message, &message.body[end_of_prefix..])
+                    }
+                    None => {
+                        if bot.verbose {
+                            println!("Command \"{}\" not found in registered handles", &command);
+                        }
+                        HandleResult::ContinueHandling
+                    }
+                }
+            }
+            None => {
+                HandleResult::ContinueHandling /* Doing nothing. Not for us */
+            }
         }
-   }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,15 @@
 //! Easy to use API for implementing your own Matrix-Bot (see matrix.org)
 //!
 //! # Basic setup:
-//! There are two parts: A MessageHandler and the MatrixBot.
+//! There are two main parts: A [`MessageHandler`] and the [`MatrixBot`].
 //! The MessageHandler defines what happens with received messages.
 //! The MatrixBot consumes your MessageHandler and deals with all
 //! the matrix-protocol-stuff, calling your MessageHandler for each
-//! new text-message.
+//! new text-message with an [`ActiveBot`] handle that allows the handler to
+//! respond to the message.
 //!
-//! You can write your own MessageHandler by implementing the `MessageHandler`-trait,
-//! or use one provided by this crate (currently only `StatelessHandler`).
+//! You can write your own MessageHandler by implementing the [`MessageHandler`]-trait,
+//! or use one provided by this crate (currently only [`StatelessHandler`]).
 //!
 //! # Multple Handlers:
 //! One can register multiple MessageHandlers with a bot. Thus one can "plug and play"
@@ -41,6 +42,11 @@
 //! }
 //! ```
 //! Have a look in the examples/ directory for detailed examples.
+//!
+//! [`MatrixBot`]: struct.MatrixBot.html
+//! [`ActiveBot`]: struct.ActiveBot.html
+//! [`MessageHandler`]: handlers/trait.MessageHandler.html
+//! [`StatelessHandler`]: handlers/stateless_handler/struct.StatelessHandler.html
 use chrono::prelude::*;
 
 use fractal_matrix_api::backend::BKCommand;
@@ -201,6 +207,8 @@ impl MatrixBot {
     }
 }
 
+/// Handle for an active bot that allows sending message, leaving rooms
+/// and shutting down the bot
 #[derive(Clone)]
 pub struct ActiveBot {
     backend: Sender<BKCommand>,


### PR DESCRIPTION
This both remove the need for the `Option::take()` jugling with handler
and allows handlers to clone to bot handle so they can later send
messages in the background