### PR TITLE
give backends a chance to initialize

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,5 +1,3 @@
-
-
 pub use fractal_matrix_api::types::Message;
 
 /// What to do after finished handling a message
@@ -11,11 +9,18 @@ pub enum HandleResult {
 }
 
 /// Any struct that implements this trait can be passed to a MatrixBot.
-/// The bot will call handle_message() on each arriving text-message
+/// The bot will call `handle_message()` on each arriving text-message
 /// The result HandleResult defines if `handle_message()` of other handlers will
 /// be called with this message or not.
+///
+/// The bot will also call `init_handler()` on startup to allow handlers to
+/// setup any background work
 pub trait MessageHandler {
+    /// Will be called for every text message send to a room the bot is in
     fn handle_message(&mut self, bot: &ActiveBot, message: &Message) -> HandleResult;
+
+    /// Will be called once the bot has started
+    fn init_handler(&mut self, _bot: &ActiveBot) {}
 }
 
 /// Convenience-function to split the incoming message by whitespace and
@@ -35,6 +40,5 @@ pub fn extract_command<'a>(message: &'a str, prefix: &str) -> Option<&'a str> {
 
 pub mod stateless_handler;
 pub use self::stateless_handler::StatelessHandler;
-
 
 use crate::ActiveBot;

--- a/src/handlers/stateless_handler.rs
+++ b/src/handlers/stateless_handler.rs
@@ -1,6 +1,6 @@
 use crate::handlers::{extract_command, HandleResult, Message, MessageHandler};
-use std::collections::HashMap;
 use crate::ActiveBot;
+use std::collections::HashMap;
 
 /// Convenience-handler that can quickly register and call functions
 /// without any state (each function-call will result in the same output)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,11 +58,8 @@ pub use fractal_matrix_api::types::{Message, Room};
 use std::sync::mpsc::channel;
 use std::sync::mpsc::{Receiver, Sender};
 
-
 pub mod handlers;
 use handlers::{HandleResult, MessageHandler};
-
-
 
 /// How messages from the bot should be formatted. This is up to the client,
 /// but usually RoomNotice's have a different color than TextMessage's.
@@ -134,8 +131,12 @@ impl MatrixBot {
         let mut active_bot = ActiveBot {
             backend: self.backend.clone(),
             uid: self.uid.clone(),
-            verbose: self.verbose
+            verbose: self.verbose,
         };
+
+        for handler in self.handlers.iter_mut() {
+            handler.init_handler(&active_bot);
+        }
 
         loop {
             let cmd = self.rx.recv().unwrap();
@@ -213,7 +214,7 @@ impl MatrixBot {
 pub struct ActiveBot {
     backend: Sender<BKCommand>,
     uid: Option<String>,
-    verbose: bool
+    verbose: bool,
 }
 
 impl ActiveBot {


### PR DESCRIPTION
the main use case here is to allow bots to automatically send messages to channels they are in.

A handler would use `init_handler` to start a thread and keep a copy of the `ActiveBot` around so it can send messages from the background thread

an empty default implementation is provided so handlers that don't require this don't have to worry about implementing the method